### PR TITLE
use tmpfs for /tmp

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -19,7 +19,7 @@ _docker() {
         -e 'GIT_CACHE_DIR=/data/gitcache' \
         -v '/home/ccache:/data/ccache' \
         -v '/srv/riot-ci/.gitcache:/data/gitcache' \
-        -v '/tmp:/tmp' \
+        --tmpfs '/tmp' \
         -w '/data/riotbuild' \
         --security-opt seccomp=unconfined \
         'riot/riotbuild:latest' $* &


### PR DESCRIPTION
By using `--tmpfs /tmp` it is ensured that `/tmp` will reside in RAM and is not exposed to the host system. On host systems where `/tmp` is mounted on disks, it generates a lot of disk i/o.

EDIT: requires docker version >= 1.10