### PR TITLE
enable git-cache autoadd feature

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -17,6 +17,7 @@ _docker() {
         -e "CI_PULL_NR=${CI_PULL_NR}" \
         -e "CI_BASE_BRANCH=${CI_BASE_BRANCH}" \
         -e 'GIT_CACHE_DIR=/data/gitcache' \
+        -e 'GIT_CACHE_AUTOADD=1' \
         -v '/home/ccache:/data/ccache' \
         -v '/srv/riot-ci/.gitcache:/data/gitcache' \
         -v '/tmp:/tmp' \


### PR DESCRIPTION
This PR enables git-cache's new auto-add for repositories feature for murdock.