### PR TITLE
remove obsolete ccache path

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -2,7 +2,7 @@ DOCKER_PID=""
 
 trap 'echo "... TERM signal received" ; [ -n "$DOCKER_PID" ] && kill -TERM $DOCKER_PID ; exit 1' SIGTERM
 
-export CCACHE="/data/riotbuild/bin/ccache"
+export CCACHE="ccache"
 
 _docker() {
     docker run --rm -u "$(id -u)" \


### PR DESCRIPTION
#5 removed the ccache binary from murdock. This PR removes the corresponding path setting.