### PR TITLE
nightlies: Provide script to generate meta-information

### DIFF
--- a/nightly.sh
+++ b/nightly.sh
@@ -10,18 +10,22 @@ BASEDIR="$(dirname $(realpath $0))"
 
 [ -f "${BASEDIR}/local.sh" ] && . "${BASEDIR}/local.sh"
 
+REPO_DIR="${HTTPROOT}/$(repo_path ${REPO})"
+
 main() {
     export NIGHTLY=1 STATIC_TESTS=0 SAVE_JOB_RESULTS=1
 
     for branch in $BRANCHES; do
         local commit="$(gethead $REPO $branch)"
-        local output_dir="${HTTPROOT}/$(repo_path $REPO)/$branch/${commit}"
+        local output_dir="${REPO_DIR}/$branch/${commit}"
 
         build_commit "$REPO" "$branch" "$commit" "$output_dir" || continue
 
         local latest_link="$(dirname "$output_dir")/latest"
         rm -f "$latest_link"
         ln -s "$output_dir" "$latest_link"
+        # generate JSON so it can be fetched by the web frontend
+        ${BASEDIR}/update_nightly_list.py ${REPO_DIR} ${branch}
     done
 }
 

--- a/update_nightly_list.py
+++ b/update_nightly_list.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python3
+
+import argparse
+import datetime
+import json
+import os
+import re
+import time
+
+FILENAME = "nightlies.json"
+
+
+def find_commit_build(builds, commit):
+    for build in builds:
+        if build["commit"] == commit:
+            return build
+    return None
+
+
+def main(repodir, branch="master"):
+    nightly_file = os.path.join(repodir, branch, FILENAME)
+    try:
+        # parse existing list file
+        with open(nightly_file) as f:
+            nightly = json.load(f)
+    except:
+        # there is no list file at the moment or a different error happened
+        # just try to create a new one
+        nightly = []
+    branch_dir = os.path.join(repodir, branch)
+    # get hash of latest commit from symlink
+    latest_commit = os.path.realpath(os.path.join(branch_dir, "latest"))\
+        .split(os.path.sep)[-1]
+    # check if it was already build in a previous build
+    build = find_commit_build(nightly, latest_commit)
+    if build is None:
+        build = {"commit": latest_commit}
+    else:
+        # remove so it is definitely at the beginning later
+        nightly.remove(build)
+    with open(os.path.join(branch_dir, "latest", "output.html")) as f:
+        c = re.compile(r"--- result: BUILD SUCCESSFUL\.")
+        build["result"] = "errored"
+        for line in f:
+            if c.match(line) is not None:
+                build["result"] = "passed"
+                break
+    build["since"] = time.mktime(datetime.datetime.now().timetuple())
+    # add latest build on top
+    nightly.insert(0, build)
+    # restrict number of builds to 7 (one week ideally)
+    nightly = nightly[:7]
+    with open(nightly_file, "w") as f:
+        json.dump(nightly, f, indent=" "*4)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument(
+            "repodir",
+            help="Web directory for the repo the nightlies are build for"
+        )
+    p.add_argument(
+            "branch",
+            help="Last build branch of the nightlies",
+            default="master",
+            nargs="?"
+        )
+    main(**vars(p.parse_args()))


### PR DESCRIPTION
This provides a script that parses all meta-information I could find and dumps them in a JSON file `/RIOT-OS/RIOT/nightlies` in a format not unsimilar to the `/api/pull_requests` method of Murdock. This is preparation for the a graphical representation of the nightlies at https://ci.riot-os.org.