### PR TITLE
common.sh: make gethead() return instead of exit

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -25,7 +25,7 @@ gethead() {
 
     RES=$?
     [ -n "$tmpdir" ] && rm -rf "$tmpdir"
-    exit $RES
+    return $RES
 }
 
 post_build() {


### PR DESCRIPTION
bash function exits instead of returning