### PR TITLE
parse_results.py: save job results in static mode

### DIFF
--- a/nightly.sh
+++ b/nightly.sh
@@ -11,7 +11,7 @@ BASEDIR="$(dirname $(realpath $0))"
 [ -f "${BASEDIR}/local.sh" ] && . "${BASEDIR}/local.sh"
 
 main() {
-    export NIGHTLY=1 STATIC_TESTS=0
+    export NIGHTLY=1 STATIC_TESTS=0 SAVE_JOB_RESULTS=1
 
     for branch in $BRANCHES; do
         local commit="$(gethead $REPO $branch)"

--- a/parse_result.py
+++ b/parse_result.py
@@ -135,6 +135,8 @@ def create_badge(filename, status="failed"):
         badge_svg.write(badge.substitute(status=status))
 
 def static():
+    save_job_results = True if os.environ.get("SAVE_JOB_RESULTS", "0") == "1" else False
+
     passed = {}
     failed = {}
     npassed = 0
@@ -159,6 +161,8 @@ def static():
             dictadd(_time, worker, result.get("runtime"))
 
             process(job)
+            if save_job_results:
+                save_job_result(job)
 
     static_tests = result_dict.pop("static_tests", {})
     if nfailed:


### PR DESCRIPTION
Currently, nightly.sh does not extract indivudual job result output into files, as is done for PR builds. It does create links, though, which then lead to nonexistant files.

This PR changes parse_result.py so it can extract those files also in static mode, and also enables that option for nightles.