### PR TITLE
parse_result.py: don't override failed_job["name"]

### DIFF
--- a/parse_result.py
+++ b/parse_result.py
@@ -473,7 +473,7 @@ def post_status(data, prnum, failed_jobs, http_root):
             filename, jobname = _tuple
             failed_job = {"name": jobname}
             if filename:
-                failed_job = {"href": os.path.join(http_root, filename)}
+                failed_job["href"] = os.path.join(http_root, filename)
             status["failed_jobs"].append(failed_job)
 
     do_post_status(status, prnum)


### PR DESCRIPTION
Currently the `name` field of a failed job is overwritten, causing them all to be shown as `undefined` during a build (since https://github.com/kaspar030/murdock/pull/17 isn't merged yet, ~~finished builds aren't effected~~ failed jobs of finished builds aren't shown). This fixes that.