### PR TITLE
README.md: fix link to worker nodes setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Its .ssh/authorized_keys will contain ssh keys for every allowed worker.
 
 ## Setup worker nodes
 
-See https://github.com/kaspar030/riotdocker/blob/dwq/README.murdock.md.
+See https://github.com/kaspar030/riotdocker/blob/dwq/README.md.
 
 ## Setup frontend HTTP proxy
 


### PR DESCRIPTION
The filename is README.md and not README.murdock.md.