### PR TITLE
always build nightlies, flush redis cache

### DIFF
--- a/nightly.sh
+++ b/nightly.sh
@@ -17,12 +17,14 @@ main() {
 
     for branch in $BRANCHES; do
         local commit="$(gethead $REPO $branch)"
-        local output_dir="${REPO_DIR}/$branch/${commit}"
+        local output_dir_commit="${REPO_DIR}/$branch/${commit}"
+        local output_dir="${output_dir_commit}.$(date +'%Y%m%d%H%M')"
+        local latest_link="$(dirname "$output_dir")/latest"
 
         build_commit "$REPO" "$branch" "$commit" "$output_dir" || continue
 
-        local latest_link="$(dirname "$output_dir")/latest"
         ln -s -f -T "$output_dir" "$latest_link" || true
+        ln -s -f -T "$output_dir" "$output_dir_commit" || true
 
         # generate JSON so it can be fetched by the web frontend
         ${BASEDIR}/update_nightly_list.py ${REPO_DIR} ${branch}

--- a/nightly.sh
+++ b/nightly.sh
@@ -22,8 +22,8 @@ main() {
         build_commit "$REPO" "$branch" "$commit" "$output_dir" || continue
 
         local latest_link="$(dirname "$output_dir")/latest"
-        rm -f "$latest_link"
-        ln -s "$output_dir" "$latest_link"
+        ln -s -f -T "$output_dir" "$latest_link" || true
+
         # generate JSON so it can be fetched by the web frontend
         ${BASEDIR}/update_nightly_list.py ${REPO_DIR} ${branch}
     done

--- a/nightly.sh
+++ b/nightly.sh
@@ -15,6 +15,9 @@ REPO_DIR="${HTTPROOT}/$(repo_path ${REPO})"
 main() {
     export NIGHTLY=1 STATIC_TESTS=0 SAVE_JOB_RESULTS=1
 
+    echo -n "--- flushing redis test result cache: "
+    redis-cli flushall
+
     for branch in $BRANCHES; do
         local commit="$(gethead $REPO $branch)"
         local output_dir_commit="${REPO_DIR}/$branch/${commit}"

--- a/update_nightly_list.py
+++ b/update_nightly_list.py
@@ -29,8 +29,9 @@ def main(repodir, branch="master"):
         nightly = []
     branch_dir = os.path.join(repodir, branch)
     # get hash of latest commit from symlink
+    # (drop possible build time suffix)
     latest_commit = os.path.realpath(os.path.join(branch_dir, "latest"))\
-        .split(os.path.sep)[-1]
+        .split(os.path.sep)[-1].split(".")[0]
     # check if it was already build in a previous build
     build = find_commit_build(nightly, latest_commit)
     if build is None:


### PR DESCRIPTION
This PR makes Murdock always build nightlies.
Previously, it would skip building a master commit that it had already built before.
That saved some redundant compilation (mostly on quiet weekends).

I had some trouble coming up with nice logic on when to flush the test result cache (https://github.com/RIOT-OS/RIOT/pull/10576):

Clear cache before building or skipping nightly? -> the first build the next day might take forever should the cache not be populated, in the case there was no new master commit.
Not clear it, if there's no new master commit? -> no defined maximum age of the cache entries.

To me the simplest solution seems to just rebuild master & release branch every night, populating a clean cache with a fresh reference.
