### PR TITLE
nightlies: allow branches to be configured via repo

### DIFF
--- a/nightly.sh
+++ b/nightly.sh
@@ -1,7 +1,6 @@
 #!/bin/sh -e
 
 REPO=https://github.com/RIOT-OS/RIOT
-BRANCHES="master"
 HTTPROOT="/srv/http/ci.riot-labs.de-devel/devel"
 
 BASEDIR="$(dirname $(realpath $0))"
@@ -11,6 +10,8 @@ BASEDIR="$(dirname $(realpath $0))"
 [ -f "${BASEDIR}/local.sh" ] && . "${BASEDIR}/local.sh"
 
 REPO_DIR="${HTTPROOT}/$(repo_path ${REPO})"
+BRANCHES=$(wget -O - ${REPO}/blob/master/.nightly-branches)
+BRANCHES=${BRANCHES:-"master"}
 
 main() {
     export NIGHTLY=1 STATIC_TESTS=0 SAVE_JOB_RESULTS=1


### PR DESCRIPTION
This allows to configure the branches which to build via the file `.nightly-branches` in the main repo. This way we could e.g. also add the current release branch during one release cycle to the nightlies.

If the file does not exist, we fall back to `master`.