### PR TITLE
fix: mail notification

### DIFF
--- a/nightly.sh
+++ b/nightly.sh
@@ -33,7 +33,7 @@ main() {
 
         # generate JSON so it can be fetched by the web frontend
         ${BASEDIR}/update_nightly_list.py ${REPO_DIR} ${branch}
-        ${BASEDIR}/notify ${REPO_DIR} ${commit} ${last_commit}
+        ${BASEDIR}/notify.py ${REPO_DIR} ${commit} ${last_commit}
     done
 }
 

--- a/notify.py
+++ b/notify.py
@@ -145,7 +145,7 @@ def main(repodir, current_build, last_build=None):
         logging.error("You can change the path to the Murdock config using "
                       "the MURDOCK_CONFIG environment variable")
         sys.exit(1)
-    if "notifications" in config:
+    if "notifications" not in config:
         logging.warning("No notifications section found in {} won't notify"
                         .format(MURDOCK_CONFIG))
         sys.exit(0)


### PR DESCRIPTION
finally found the missing pieces why mail notifications didn't work, though everything was configured and setup as needed.

Problem were two easy to overlook typos 😄 

Already fixed in deployment. 

On a side note: currently info is send to ci@riot-labs.de, bc IIRC only list members can send to maintainer@riot-os.org (btw. this was also a typo in the original PR which used maintainers@riot-os.org (plural)).

see #24