### PR TITLE
common.sh: build(): add "--maxfail 500" to build command

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -71,7 +71,7 @@ build() {
 
     get_jobs | dwqc \
         -E NIGHTLY \
-        --quiet --outfile result.json
+        --quiet --maxfail 500 --outfile result.json
 
     RES=$?
 


### PR DESCRIPTION
Should prevent disque memory errors (as caused by https://github.com/RIOT-OS/RIOT/pull/12877).

This is live already on ci.riot-os.org.