### PR TITLE
pass CI_PULL_LABELS to get_jobs

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -38,7 +38,8 @@ post_build() {
 }
 
 get_jobs() {
-    dwqc -E NIGHTLY -E STATIC_TESTS -E APPS -E BOARDS './.murdock get_jobs'
+    dwqc -E CI_PULL_LABELS -E NIGHTLY -E STATIC_TESTS -E APPS -E BOARDS \
+        './.murdock get_jobs'
 }
 
 build() {


### PR DESCRIPTION
This change makes murdock pass the labels not only to the build steps, but also to the get_jobs stage.
Needed for https://github.com/RIOT-OS/RIOT/pull/13337.

(This is already live).