### PR TITLE
build.sh: pass CI_BASE_COMMIT to jobs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -124,6 +124,7 @@ case "$ACTION" in
         get_jobs | dwqc \
             -E CI_BASE_REPO -E CI_BASE_BRANCH -E CI_PULL_REPO -E CI_PULL_COMMIT \
             -E CI_PULL_NR -E CI_PULL_URL -E CI_PULL_LABELS -E CI_MERGE_COMMIT \
+            -E CI_BASE_COMMIT \
             --quiet --report $REPORT_QUEUE --outfile result.json
 
         RES=$?


### PR DESCRIPTION
Already live, working fine. Needed for https://github.com/RIOT-OS/RIOT/pull/13430.