### PR TITLE
remove metrics collection debug output

### DIFF
--- a/post-build.d/01metrics.py
+++ b/post-build.d/01metrics.py
@@ -28,7 +28,6 @@ def extract_json_metrics(output):
         if line.startswith("{"):
             try:
                 metric = json.loads(line)
-                print(metrics, metric)
                 metrics = merge(metrics, metric)
             except json.decoder.JSONDecodeError:
                 pass


### PR DESCRIPTION
there's a leftover debug print in the code.

See its effect e.g., [here](https://ci.riot-os.org/RIOT-OS/RIOT/14661/8d50a597eef366ada2f4529ddc157855c212abc9/output.html).