### PR TITLE
build.sh: PR update labels

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ MERGE_COMMIT_REPO="murdock-ci/RIOT"
 BASEDIR="$(dirname $(realpath $0))"
 
 . "${BASEDIR}/common.sh"
+. "${BASEDIR}/github.sh"
 
 [ -f "${BASEDIR}/local.sh" ] && . "${BASEDIR}/local.sh"
 
@@ -105,6 +106,8 @@ case "$ACTION" in
         export DWQ_COMMIT="${CI_MERGE_COMMIT}"
 
         echo "---- using merge commit SHA1=${CI_MERGE_COMMIT}"
+
+        update_CI_PULL_LABELS $(github_url_to_repo $CI_BASE_REPO) "$CI_PULL_NR"
 
         dwqc "test -x .murdock" || {
             echo "PR does not contain .murdock build script, please rebase!"

--- a/github.sh
+++ b/github.sh
@@ -1,0 +1,54 @@
+# get labels of a specific PR as json list
+# args: repo in "ORG/REPO" form
+#       pr_num
+get_pr_labels() {
+    local repo=$1
+    local pull_request_number=$2
+
+    (
+        echo -n "["
+        get_pr_labels_raw "$repo" "$pull_request_number" | \
+            grep name | tr -d '\n' | sed -e 's/\s*"name": / /g'
+        echo "]"
+    ) | sed -e 's/,]$/ ]/'
+}
+
+# get labels of a specific PR, raw json response
+# args: repo in "ORG/REPO" form
+#       pr_num
+get_pr_labels_raw() {
+    local repo=$1
+    local pull_request_number=$2
+
+    curl -sS "https://api.github.com/repos/${repo}/issues/${pull_request_number}/labels"
+}
+
+# get labels of a specific repository
+get_repo_labels() {
+    local repo=$1
+
+    curl "https://api.github.com/repos/${repo}/labels"
+}
+
+update_CI_PULL_LABELS() {
+    local repo="$1"
+    local pr_num="$2"
+
+    echo "--- updating labels for ${repo}#${pr_num}..."
+    local labels="$(get_pr_labels $repo $pr_num)"
+    if [ -n "$labels" ]; then
+        if [ "$labels" != "[]" ]; then
+            echo "-- updated PR labels:"
+            echo "-- $labels"
+            export CI_PULL_LABELS="$labels"
+        else
+            echo "warning: updating labels failed, got empty set"
+        fi
+    else
+        echo "warning: updating labels failed!"
+    fi
+}
+
+github_url_to_repo() {
+    echo "$1" | sed -E 's=^https?://github\.com/==g' | sed 's/\.git$//g'
+}


### PR DESCRIPTION
This PR makes build.sh get a fresh copy of a PR's labels, from github.

Currently, Murdock passes `CI_PULL_LABELS` with the labels as set _at the time the build get's queued_. The process is racey, e.g., sometimes selecting both "ready for build" and "run tests" queues with "ready for build" set, then sets "run tests" too late.

With this PR, murdock updates the labels after starting the build, before collection jobs.
Some fail saves only updates the labels if the crude curl script actually returns any labels.
This should work, as "CI: ready for build" should always be set.