### PR TITLE
unify dwq environment options, pass more to "get_jobs"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -124,10 +124,11 @@ case "$ACTION" in
 
         set +e
 
-        get_jobs | dwqc \
-            -E CI_BASE_REPO -E CI_BASE_BRANCH -E CI_PULL_REPO -E CI_PULL_COMMIT \
+        export DWQ_ENV="-E CI_BASE_REPO -E CI_BASE_BRANCH -E CI_PULL_REPO -E CI_PULL_COMMIT \
             -E CI_PULL_NR -E CI_PULL_URL -E CI_PULL_LABELS -E CI_MERGE_COMMIT \
-            -E CI_BASE_COMMIT \
+            -E CI_BASE_COMMIT -E APPS -E BOARDS -E NIGHTLY -E STATIC_TESTS"
+
+        get_jobs | dwqc ${DWQ_ENV} \
             --maxfail 500 \
             --quiet --report $REPORT_QUEUE --outfile result.json
 

--- a/common.sh
+++ b/common.sh
@@ -38,8 +38,7 @@ post_build() {
 }
 
 get_jobs() {
-    dwqc -E CI_PULL_LABELS -E NIGHTLY -E STATIC_TESTS -E APPS -E BOARDS \
-        './.murdock get_jobs'
+    dwqc ${DWQ_ENV} './.murdock get_jobs'
 }
 
 build() {


### PR DESCRIPTION
https://github.com/RIOT-OS/RIOT/pull/17325 needs "get_jobs" to receive the commit info, which the current scripts don't provide.

This PR exports all needed "-E env" options into a variable so that can be set once.