### PR TITLE
post-build.d/01metrics.py: concatenate list values with same key

### DIFF
--- a/post-build.d/01metrics.py
+++ b/post-build.d/01metrics.py
@@ -11,7 +11,11 @@ def merge(a, b, path=None):
     for key in b:
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):
+                # merge dics
                 merge(a[key], b[key], path + [str(key)])
+            elif isinstance(a[key], list) and isinstance(b[key], list):
+                # concatenate lists
+                a[key] = a[key] + b[key]
             elif a[key] == b[key]:
                 pass # same leaf value
             else:


### PR DESCRIPTION
[#17706](https://github.com/RIOT-OS/RIOT/pull/17706) adds stack usage metrics.

Unfortunately, some RIOT tests re-start a thread, leading to multiple values with the same name. That tripped the current metrics merging logic, because there where duplicate keys with differing values (`"thread": { "used": 123}, "thread": { "used: 3210}`).

So, [#17706](https://github.com/RIOT-OS/RIOT/pull/17706) now prints the threads in a list, with "name" being just a field.
That now needs to be concatenated, to get this result:

<details>

```
    1 {                                                                                                                                            
    2     "metrics": {                                                                                                                             
    3         "tests/malloc_thread_safety": {                                                                                                      
    4             "native:gnu": {                                                                                                                  
    5                 "threads": [                                                                                                                 
    6                     {                                                                                                                        
    7                         "name": "t1",                                                                                                        
    8                         "stack_size": 4096,                                                                                                  
    9                         "stack_used": 860                                                                                                    
   10                     },                                                                                                                       
   11                     {                                                                                                                        
   12                         "name": "t2",                                                                                                        
   13                         "stack_size": 4096,                                                                                                  
   14                         "stack_used": 860                                                                                                    
   15                     },                                                                                                                       
   16                     {                                                                                                                        
   17                         "name": "t1",                                                                                                        
   18                         "stack_size": 4096,                                                                                                  
   19                         "stack_used": 472                                                                                                    
   20                     },                                                                                                                       
   21                     {                                                                                                                        
   22                         "name": "t2",                                                                                                        
   23                         "stack_size": 4096,                                                                                                  
   24                         "stack_used": 472                                                                                                    
   25                     },                                                                                                                       
```
</details>

This needs support in 01metrics.py, otherwise there's a conflict still:
```
- running script "/opt/murdock2/scripts/post-build.d/01metrics.py"
Traceback (most recent call last):
  File "/opt/murdock2/scripts/post-build.d/01metrics.py", line 76, in 
    main()
  File "/opt/murdock2/scripts/post-build.d/01metrics.py", line 64, in main
    metrics = extract_json_metrics(result["output"])
  File "/opt/murdock2/scripts/post-build.d/01metrics.py", line 31, in extract_json_metrics
    metrics = merge(metrics, metric)
  File "/opt/murdock2/scripts/post-build.d/01metrics.py", line 18, in merge
    raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
Exception: Conflict at threads
```

I've tested with another full result.json that this doesn't break current metrics selection.