### PR TITLE
implement fast failing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -131,15 +131,16 @@ set_status() {
 main() {
     set_status "fetching code"
 
-    export APPS BOARDS
+    export APPS BOARDS NIGHTLY STATIC_TESTS RUN_TESTS
+
+    export DWQ_ENV="-E APPS -E BOARDS -E NIGHTLY -E STATIC_TESTS -E RUN_TESTS \
+                    -E CI_MURDOCK_PROJECT -E ENABLE_TEST_CACHE -E CI_FAST_FAIL \
+                    -E FULL_BUILD"
 
     local repo_dir="RIOT"
     if [ -n "${CI_BUILD_COMMIT}" ]; then
-        export NIGHTLY STATIC_TESTS
         export DWQ_REPO="${CI_GIT_URL_WORKER}/${CI_BUILD_REPO_WORKER}"
         export DWQ_COMMIT="${CI_BUILD_COMMIT}"
-        export DWQ_ENV="-E APPS -E BOARDS -E NIGHTLY -E STATIC_TESTS -E RUN_TESTS \
-                        -E CI_MURDOCK_PROJECT -E ENABLE_TEST_CACHE"
 
         checkout_commit ${repo_dir} ${GITHUB_REPO_URL} ${CI_BUILD_COMMIT}
 
@@ -189,10 +190,9 @@ main() {
 
         echo "-- Building PR #${CI_PULL_NR} ${CI_PULL_URL} head: ${CI_PULL_COMMIT}..."
 
-        export DWQ_ENV="-E CI_BASE_REPO -E CI_BASE_BRANCH -E CI_PULL_REPO -E CI_PULL_COMMIT \
+        export DWQ_ENV="${DWQ_ENV} -E CI_BASE_REPO -E CI_BASE_BRANCH -E CI_PULL_REPO -E CI_PULL_COMMIT \
             -E CI_PULL_NR -E CI_PULL_URL -E CI_PULL_LABELS -E CI_MERGE_COMMIT \
-            -E CI_BASE_COMMIT -E APPS -E BOARDS -E NIGHTLY -E STATIC_TESTS -E RUN_TESTS \
-            -E CI_MURDOCK_PROJECT -E ENABLE_TEST_CACHE"
+            -E CI_BASE_COMMIT"
     else # Invalid configuration, aborting
         echo "Invalid job configuration, return with error"
         exit 2


### PR DESCRIPTION
This implements fast failing a build on first error.

The semantics are:

- default to FAST_FAIL
- disable FAST_FAIL if NIGHTLY=1
- disable FAST_FAIL if "CI: no fast fail" is set

The commit piggy-backs some re-ordering and deduplicating of DWQ_ENV handling.