### PR TITLE
dwq export CI_BUILD_BRANCH

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -158,7 +158,7 @@ main() {
 
     export DWQ_ENV="-E APPS -E BOARDS -E NIGHTLY -E STATIC_TESTS -E RUN_TESTS \
                     -E CI_MURDOCK_PROJECT -E ENABLE_TEST_CACHE -E CI_FAST_FAIL \
-                    -E FULL_BUILD"
+                    -E FULL_BUILD -ECI_BUILD_BRANCH"
 
     local repo_dir="RIOT"
     if [ -n "${CI_BUILD_COMMIT}" ]; then


### PR DESCRIPTION
This fixes "staging" being built as quickbuild. the `build.sh` doesn't pass the branch information through to .`murdock.sh`.

build without this fix:
https://ci-staging.riot-os.org/details/9445a881136a4e65b333e3278525d4b2

build with this fix:
https://ci-staging.riot-os.org/details/04eed06e18db4e0ebbddb247b0c6bce3