### PR TITLE
common.py: handle missing "runtime" job result field

### DIFF
--- a/common.py
+++ b/common.py
@@ -23,7 +23,7 @@ def parse_job(job):
     result = {}
     result["status"] = job["result"]["status"] in { 0, "0", "pass" }
     result["worker"] = job["result"]["worker"]
-    result["runtime"] = float(job["result"]["runtime"])
+    result["runtime"] = float(job["result"].get("runtime", 0))
     result["output"] = job["result"]["output"]
     result["name"] = os.path.join(
         *job["result"]["body"]["command"].split()[1:]


### PR DESCRIPTION
"dwq-subjob" might send these.

```
Traceback (most recent call last):
  File "/opt/murdock-scripts/reporter.py", line 175, in <module>
    main()
  File "/opt/murdock-scripts/reporter.py", line 126, in main
    job = parse_job(job_raw)
  File "/opt/murdock-scripts/common.py", line 26, in parse_job
    result["runtime"] = float(job["result"]["runtime"])
KeyError: 'runtime'