### PR TITLE
Install python3-venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         graphviz \
         make \
         python3-pip \
+        python3-venv \
         ssh-client \
         tini \
         wget \


### PR DESCRIPTION
This is a copy in spirit of https://github.com/RIOT-OS/riotdocker/pull/250, now where it actually belongs: It allows the `make doc` to use virtual environments to install some extra software. Thus, it enables testing of https://github.com/RIOT-OS/RIOT/pull/20395.