### PR TITLE
add chronic, use for "make doc"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
         git \
         graphviz \
         make \
+        moreutils \
         python3-pip \
         python3-venv \
         ssh-client \

--- a/build.sh
+++ b/build.sh
@@ -278,7 +278,7 @@ main() {
     # Only build Doxygen documentation if the build job was successful
     if [ ${build_test_res} -eq 0 ]; then
         echo "-- Building Doxygen documentation"
-        make -C ${repo_dir} doc --no-print-directory 2>/dev/null
+        chronic make -C ${repo_dir} doc --no-print-directory
         cp -R ${repo_dir}/doc/doxygen/html ./doc-preview
     fi
 


### PR DESCRIPTION
This is deployed on "ci-staging.riot-os.org", sample output here: ~~https://ci-staging.riot-os.org/details/450ac44394bc4e1d8737c73cfae55df6/output~~ (that was *without this pr) this is with: https://ci-staging.riot-os.org/details/575aec06aadc405a923c6d6ca63518ab