### PR TITLE
build.sh: Set RIOTBASE when running make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -278,7 +278,7 @@ main() {
     # Only build Doxygen documentation if the build job was successful
     if [ ${build_test_res} -eq 0 ]; then
         echo "-- Building Doxygen documentation"
-        chronic make -C ${repo_dir} doc --no-print-directory
+        RIOTBASE=${repo_dir} chronic make -C ${repo_dir} doc --no-print-directory
         cp -R ${repo_dir}/doc/doxygen/html ./doc-preview
     fi
 


### PR DESCRIPTION
Almost all of make works fine without RIOTBASE, but RIOTBOARD is not set correctly without it.

We could go try figure out how to make our make processes more resilient, but at this point I'm sufficiently deep in debugging to just call them brittle and acknowledge that application Makefiles just set RIOTBASE and that top-level make is typically called just from there.