### PR TITLE
Dockerfile: Install python3-yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         moreutils \
         python3-pip \
         python3-venv \
+        python3-yaml \
         ssh-client \
         tini \
         wget \


### PR DESCRIPTION
This allows `make doc` to run again in the CI.