### PR TITLE
Revert "Dockerfile: Install python3-yaml"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
         moreutils \
         python3-pip \
         python3-venv \
-        python3-yaml \
         ssh-client \
         tini \
         wget \


### PR DESCRIPTION
In #57 PyYAML is installed in the correct way. No need to bloat the container with the same python module installed twice.