### PR TITLE
build.sh: Change Doxygen command to `doc-ci`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -278,7 +278,7 @@ main() {
     # Only build Doxygen documentation if the build job was successful
     if [ ${build_test_res} -eq 0 ]; then
         echo "-- Building Doxygen documentation"
-        chronic make -C ${repo_dir} doc --no-print-directory
+        chronic make -C ${repo_dir} doc-ci --no-print-directory
         cp -R ${repo_dir}/doc/doxygen/html ./doc-preview
     fi
 


### PR DESCRIPTION
With https://github.com/RIOT-OS/RIOT/pull/21300 merged, the command for building the documentation can be changed to `doc-ci` to generate the documentation with the Doxygen version specified in `$(RIOTBASE)/doc/doxygen/Makefile`.

With `doc-ci`, the build system will download the specified Doxygen binaries and use those to generate the documentation instead of relying on the Doxygen version provided by the Ubuntu repositories (which is ooooooold).

Furthermore, it can be updated from within the RIOT repository without changing the build scripts.

See also: https://github.com/RIOT-OS/RIOT/issues/21106